### PR TITLE
execution-api: Get execution by id

### DIFF
--- a/backend/src/main/java/io/zahori/server/controller/ExecutionsController.java
+++ b/backend/src/main/java/io/zahori/server/controller/ExecutionsController.java
@@ -1,0 +1,48 @@
+package io.zahori.server.controller;
+
+import io.zahori.server.model.Execution;
+import io.zahori.server.service.ExecutionService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+/**
+ * The type Execution controller.
+ */
+@RestController
+@RequestMapping("/api/execution")
+public class ExecutionsController {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExecutionsController.class);
+
+    @Autowired
+    private ExecutionService executionService;
+
+    /**
+     * Gets execution by id
+     *
+     * @param executionId  the execution id
+     * @return the execution
+     */
+    @GetMapping(path = "/{executionId}")
+    public ResponseEntity<Object> getExecutionById(@PathVariable Long executionId) {
+        try {
+            LOG.info("get execution controller");
+
+            Optional<Execution> execution = executionService.getExecutionById(executionId);
+
+            return new ResponseEntity<>(execution, HttpStatus.OK);
+        } catch (Exception e) {
+            LOG.error(e.getMessage());
+            return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend/src/main/java/io/zahori/server/service/ExecutionService.java
+++ b/backend/src/main/java/io/zahori/server/service/ExecutionService.java
@@ -114,6 +114,16 @@ public class ExecutionService {
     }
 
     /**
+     * Get execution.
+     *
+     * @param executionId the execution id
+     * @return the execution
+     */
+    public Optional<Execution> getExecutionById(Long executionId) {
+        return executionsRepository.findById(executionId);
+    }
+
+    /**
      * Create execution.
      *
      * @param execution the execution


### PR DESCRIPTION
Hello, I'm adding what I think is a useful feature: get the execution by ID.
We are implementing a bot for running tests while building a new release, and we need a fast way of knowing the status of the execution without parsing all the existing ones on the process.